### PR TITLE
Add a Dockerfile with rustup nightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update && \
         git \
         ssh \
         libssl-dev \
-        pkg-config 
+        pkg-config && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV RUSTUP_HOME=/rust
 ENV CARGO_HOME=/cargo 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:jessie-slim
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        ssh \
+        libssl-dev \
+        pkg-config 
+
+ENV RUSTUP_HOME=/rust
+ENV CARGO_HOME=/cargo 
+ENV PATH=/cargo/bin:/rust/bin:$PATH
+
+RUN (curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --no-modify-path) && rustup default nightly

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# rustup-nightly
+
+A base docker image for building against the latest nightly.
+
+This image should be extended.  For example:
+
+```Dockerfile
+FROM linkerd/rustup-nightly:latest
+
+RUN rustup update nightly && cargo install rustfmt && cargo install clippy
+
+COPY . /app
+WORKDIR /app
+RUN cargo clippy
+```


### PR DESCRIPTION
debian:jessie-slim is used to save space. alpine may not be used, because we
need a really buildchain.