### PR TITLE
Provide an install-rust.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV RUSTUP_HOME=/rust
 ENV CARGO_HOME=/cargo 
 ENV PATH=/cargo/bin:/rust/bin:$PATH
 
-RUN (curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --no-modify-path) && rustup default nightly
+RUN echo "(curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --no-modify-path) && rustup default nightly" > /install-rust.sh && chmod 755 /install-rust.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This image should be extended.  For example:
 ```Dockerfile
 FROM linkerd/rustup-nightly:latest
 
-RUN rustup update nightly && cargo install rustfmt && cargo install clippy
+RUN /install-rust.sh && cargo install rustfmt && cargo install clippy
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Due to moby/moby#25409, we are unable to update rust if it is already installed.

This image is simplified to support /install-rust.sh which installs rustup and
defaults to nightly.